### PR TITLE
suggestion: use @instance_variables to feed templates with data

### DIFF
--- a/sinatra-templates/sinatra-templates.rb
+++ b/sinatra-templates/sinatra-templates.rb
@@ -18,10 +18,10 @@ class Person
 end
 
 get '/' do
-  participants = [
+  @participants = [
     Person.new("Laura Liegener" , 999) ,
     Person.new("Leo Eckwert"    , 123) ,
     Person.new("Meike Fischer"  , 567) ,
   ]
-  haml :index, :locals => {:participants => participants}
+  haml :index
 end

--- a/sinatra-templates/views/index.haml
+++ b/sinatra-templates/views/index.haml
@@ -6,7 +6,7 @@
     %th Last Name
     %th Phone Number
 
-  - participants.each do |participant|
+  - @participants.each do |participant|
     %tr
       %td= participant.first_name
       %td= participant.last_name


### PR DESCRIPTION
This is just a suggestion! In Sinatra, ```@instance_variables``` declared in a `get` block or similar are immediately accessible in the rendered template. Don't merge this pull request if you like `:locals => {...}` more. :smile_cat: 

By the way, your application looks pretty awesome :+1: :tada: 