### PR TITLE
Add failing specs, use shared examples

### DIFF
--- a/railsgirls/db/seeds.rb
+++ b/railsgirls/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+
+Category.create!([{
+  name: "Interesting"
+},{
+  name: "Inspirational"
+},{
+  name: "Worth spreading"
+}])

--- a/railsgirls/spec/models/category_spec.rb
+++ b/railsgirls/spec/models/category_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
+require 'support/shared_examples/unique_and_present_name'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it_behaves_like 'a model with unique and present name'
 end

--- a/railsgirls/spec/models/idea_spec.rb
+++ b/railsgirls/spec/models/idea_spec.rb
@@ -1,19 +1,6 @@
 require "rails_helper"
+require 'support/shared_examples/unique_and_present_name'
 
 describe Idea do
-  context 'without a name' do
-    subject { Idea.new(name: '')          }
-    it      { is_expected.not_to be_valid }
-  end
-
-  context 'with a duplicate name' do
-    before  { Idea.new(name: 'Test').save! }
-    subject { Idea.new(name: 'Test')       }
-    it      { is_expected.not_to be_valid  }
-
-    context 'bypassing validations' do
-      subject { Idea.new(name: 'Test').save(validate: false)                   }
-      it      { expect{ subject }.to raise_error ActiveRecord::RecordNotUnique }
-    end
-  end
+  it_behaves_like 'a model with unique and present name'
 end

--- a/railsgirls/spec/models/idea_spec.rb
+++ b/railsgirls/spec/models/idea_spec.rb
@@ -3,4 +3,9 @@ require 'support/shared_examples/unique_and_present_name'
 
 describe Idea do
   it_behaves_like 'a model with unique and present name'
+
+  context "without a category" do
+    subject { described_class.new(name: "Aha!", category: nil) }
+    it { is_expected.not_to be_valid }
+  end
 end

--- a/railsgirls/spec/support/shared_examples/unique_and_present_name.rb
+++ b/railsgirls/spec/support/shared_examples/unique_and_present_name.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+RSpec.shared_examples "a model with unique and present name" do |parameter|
+  context 'without a name' do
+    subject { described_class.new(name: '')          }
+    it      { is_expected.not_to be_valid }
+  end
+
+  context 'with a duplicate name' do
+    before  { described_class.new(name: 'Test').save! }
+    subject { described_class.new(name: 'Test')       }
+    it      { is_expected.not_to be_valid  }
+
+    context 'bypassing validations' do
+      subject { described_class.new(name: 'Test').save(validate: false)                   }
+      it      { expect{ subject }.to raise_error ActiveRecord::RecordNotUnique }
+    end
+  end
+end


### PR DESCRIPTION
Hey @veracl I've added some failing tests for you to solve. Since there is no blank in the select box in the form for `Idea`, I assumed every `Idea` must have a `category`. We will have a look into test data setup with e.g. `factory_girl` today.